### PR TITLE
ci: Integrate with Coveralls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,12 @@
 name: Test
 
 on:
-  # Run at 00:00 on Monday or manual trigger
-  schedule:
-    - cron: "0 0 * * 1"
-  workflow_dispatch: # Allows manual triggering
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch: # Manual trigger
+  schedule:
+    - cron: "0 0 * * 1" # Run at 00:00 on Monday
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,4 +32,21 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Run tests
-        run: uv run -- pytest -vv --cov=dlc --cov-report=xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uv run -- pytest -vv --cov-report=xml
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel: true
+          flag-name: python-${{ matrix.python-version }}
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # Dependency License Collector
 
+[![Test](https://github.com/sgryjp/dependency-license-collector/actions/workflows/ci.yaml/badge.svg)](https://github.com/sgryjp/dependency-license-collector/actions/workflows/ci.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/sgryjp/dependency-license-collector/badge.svg?branch=ci/use-coveralls)](https://coveralls.io/github/sgryjp/dependency-license-collector?branch=ci/use-coveralls)
+
 > A tool for collecting dependency licenses in software projects.
 
 ## Supported Inputs

--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
   "words": [
     "apache-flink",
     "bugtrack_url",
+    "coverallsapp",
     "levelname",
     "libdeeplake",
     "NOASSERTION",


### PR DESCRIPTION
This PR integrate this repository with [Coveralls](https://coveralls.io/).

The coverage report will be available at: <https://coveralls.io/github/sgryjp/dependency-license-collector>