### PR TITLE
fix: Ignore extra entries in `.env` file

### DIFF
--- a/src/dlc/settings.py
+++ b/src/dlc/settings.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     github_token: Optional[str] = None
     max_workers: Optional[int] = None
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 
 SETTINGS = Settings()


### PR DESCRIPTION
When executed in another app's workspace, there can be a `.env` file for the app. In that case, the content of the file is highly likely incompatible with DLC's environment variable set. Since such usee case is expected to be common, we should just ignore unknown keys inside the file.

Close #7 